### PR TITLE
Adjust the exported declarations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,14 @@
-import { Binding } from './Binding'
-import { BindingResolutionError } from './errors/BindingResolutionError'
-import { Container } from './Container'
+// Classes
+export { Binding } from './Binding'
+export { Container } from './Container'
 
-export {
-  Binding,
-  BindingResolutionError,
-  Container
-}
+// Errors
+export { BindingResolutionError } from './errors/BindingResolutionError'
+
+// Interfaces
+export { BindingInterface } from './interfaces/BindingInterface'
+export { ContainerInterface } from './interfaces/ContainerInterface'
+
+// Types
+export { Provider } from './types/Provider'
+export { Resolver } from './types/Resolver'


### PR DESCRIPTION
The index.ts file was only exporting the classes provided by the library, but the interfaces and types were not as accessible. This change ensures that all the library’s parts are available for use.