### PR TITLE
Update README.md to contain improved import syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ yarn add @halliganjs/service-container
 The Service Container is a class that needs to be instantiated. The resulting instance should be exported for use throughout your application as a singleton so that everything interacts with the same instance of the container.
 
 ```js
-const Container = require('@halliganjs/service-container')
+const { Container } = require('@halliganjs/service-container')
 
 const container = new Container()
 


### PR DESCRIPTION
I was playing around with this today. The documentation about importing and creating an instance of `Container` were not working for me. By changing the import statement from `const Container = require('@halliganjs/service-container')` to `const { Container } = require('@halliganjs/service-container')` the import was successful.